### PR TITLE
Refactor to not throw exception from require(); handle errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ Simple node.js library for receiving events from an aluminum Apple Remote
 [![NPM](https://nodei.co/npm/node-apple-remote.png?mini=true)][1]
 
 ```javascript
+var AppleRemote = require('node-apple-remote');
+var remote = new AppleRemote();
 try {
-    require('node-apple-remote')
-        .on('left', /* ... */)
-        .on('left.long', /* ... */)
-        .on('left.long.released', /* ... */)
-        .on('center', /* ... */)
-        .on('center.long', /* ... */)
+    remote.open()
+          .on('left', /* ... */)
+          .on('left.long', /* ... */)
+          .on('left.long.released', /* ... */)
+          .on('center', /* ... */)
+          .on('center.long', /* ... */)
 } catch (e) {
     // an exception is thrown if the apple remote
     //  device was not found on the system

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-apple-remote",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "description": "Simple event-driven interface to Aluminum Apple Remote",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
After a long period of use, the device would raise an error
and stop working; with this refactor, those errors should automatically
be handled by closing the device and re-opening it.

This will be released as v1.0.0 due to the breaking API change
